### PR TITLE
added file_reader, which returns a reader instead of the filename

### DIFF
--- a/file_reader.go
+++ b/file_reader.go
@@ -1,0 +1,39 @@
+package flagvar
+
+import (
+	"bufio"
+	"os"
+)
+
+type FileReader struct {
+	Validate func(os.FileInfo, error) error
+	Name     string
+
+	Value *bufio.Reader
+}
+
+func (fv *FileReader) Set(v string) error {
+	_, err := os.Stat(v)
+	if err != nil {
+		return err
+	}
+
+	inFile, err := os.Open(v)
+	if err != nil {
+		return err
+	}
+
+	inputReader := bufio.NewReader(inFile)
+	fv.Name = v
+	fv.Value = inputReader
+
+	return err
+}
+
+func (fv *FileReader) Get() *bufio.Reader {
+	return fv.Value
+}
+
+func (fv *FileReader) String() string {
+	return fv.Name
+}

--- a/file_reader_test.go
+++ b/file_reader_test.go
@@ -1,0 +1,19 @@
+package flagvar_test
+
+import (
+	"flag"
+	"testing"
+
+	"github.com/sgreben/flagvar"
+)
+
+func TestFileReader(t *testing.T) {
+	fr := flagvar.FileReader{}
+	var fs flag.FlagSet
+	fs.Var(&fr, "f", "input file")
+
+	err := fs.Parse([]string{"-f", "./noSuchFile.tpl"})
+	if err == nil {
+		t.Fail()
+	}
+}


### PR DESCRIPTION
Its been a long time since I contributed any of these.  I was made a file reader today and thought I should send it up to your project.  Its used in the expected way:

```
        var fr FileReader
        flag.Var(&fr, "f", "file to read from defaults to stdin")
        flag.Parse()
        // fr.Get() returns the opened reder on the file
	fileScanner := bufio.NewScanner(fr.Get())

```

Of course FileScanner is obvious now.  That's what I'm using here, but I didn't want to go nuts.  I think FileReader is more general.

